### PR TITLE
Fix for offset when find-replace bar is present

### DIFF
--- a/MiniMapViewManager.js
+++ b/MiniMapViewManager.js
@@ -171,10 +171,12 @@ define(function (require, exports, module) {
             sliderHeight = slider.height(),
             minicodHeight = minicode.outerHeight() / zoomRatio,
             scrollbarHeight = Math.min(wrapper.height(), minicodHeight),
-
+            searchBar = $(".content>.modal-bar"),
+            
             codeHeight = $(currentEditor.getRootElement()).find(".CodeMirror-sizer").height(),
+            barHeight = searchBar.length === 1 ? searchBar.outerHeight() : 0,
 
-            adjustedY = y - sliderHeight / 2 - topAdjust;
+            adjustedY = y - sliderHeight / 2 - topAdjust - barHeight;
 
         adjustedY *= (codeHeight - editorHeight)  / (scrollbarHeight - sliderHeight);
 


### PR DESCRIPTION
Calculation for scrollTo is off when a search-bar is present. This change corrects it by subtracting the search-bar height if present
