### PR TITLE
Fixed deprecation warning.

### DIFF
--- a/MiniMapViewManager.js
+++ b/MiniMapViewManager.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
         EditorManger  = brackets.getModule("editor/EditorManager"),
         CodeMirror = brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"),
         PreferencesManager = brackets.getModule('preferences/PreferencesManager'),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache"),
 
         Config = require('Config'),
         Prefs = PreferencesManager.getExtensionPrefs(Config.NAME),


### PR DESCRIPTION
Fixed deprecation warning by replacing three calls to the global mustache with calls to the third-party mustache.